### PR TITLE
Bump Flask and Jinja2 beyond security releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Flask==0.12
+Flask~=0.12.4
 Flask-FlatPages==0.3
 houdini.py==0.1.0
-Jinja2==2.10
+Jinja2~=2.10.1
 misaka==1.0.2
 pygments==1.6
 simplejson==2.6.2


### PR DESCRIPTION
Weird, locally the minor version got me the latest, but GH still complains so I'll change it to require at least the latest patch.